### PR TITLE
Fix wrong tasks for tau-retail

### DIFF
--- a/tau_bench/envs/retail/tasks.py
+++ b/tau_bench/envs/retail/tasks.py
@@ -167,7 +167,7 @@ tasks = [
                 "arguments": {
                     "order_id": "#W6390527",
                     "item_ids": ["8538875209"],
-                    "payment_method_id": "paypal_9497703",
+                    "payment_method_id": "paypal_7644869",
                 },
             },
         ],
@@ -2269,7 +2269,7 @@ tasks = [
                 },
             }
         ],
-        "instruction": "You name is Yusuf Hernandez and your email is yusuf.hernandez8836@example.com. You are shy, rigid. You want to exchange your Fleece Jacket red color and half zipper.",
+        "instruction": "You name is Yusuf Hernandez and your email is yusuf.hernandez8836@example.com. You are shy, rigid. You want to exchange your Fleece Jacket for a large red Fleece Jacket with a half zipper",
         "annotator": 4,
     },
     {
@@ -2297,7 +2297,7 @@ tasks = [
                 },
             },
         ],
-        "instruction": "You name is Yusuf Hernandez and your email is yusuf.hernandez8836@example.com. You are shy, rigid. You want to exchange your Fleece Jacket red color and half zipper. You also want to want to change your default address to your Washington DC address (which you do not want to reveal but is in one of the orders).",
+        "instruction": "You name is Yusuf Hernandez and your email is yusuf.hernandez8836@example.com. You are shy, rigid. You want to exchange your Fleece Jacket to red color and half zipper. You also want to want to change your default address to your Washington DC address (which you do not want to reveal but is in one of the orders).",
         "annotator": 4,
     },
     {


### PR DESCRIPTION
First and foremost, we want to express our sincere gratitude for creating such an excellent benchmark. The `tau-retail` test dataset is a valuable resource for validating methodologies in the field.

During our evaluation process, we identified some issues that we believe need addressing to enhance the benchmark's reliability and robustness. Specifically:

1. Some examples contain incorrect r_actions (recommended actions).
2. Certain user instructions are ambiguous or miswritten and need clarification.

This pull request aims to rectify these issues, improving the quality and accuracy of the test dataset. These enhancements will lead to more reliable model evaluations, ultimately benefiting the entire research community.

Changes made:
- Corrected r_actions in examples where they were incorrect
- Clarified ambiguous user instructions to make them more specific and clear

We believe these issues, if left unaddressed, could affect the robustness and reliability of the benchmark. 

Related issue: #3

We kindly request a review of these changes. If you notice any other examples that need correction or clarification, please let us know, and we'll address them in this PR or create a follow-up task.

Thank you for considering our contribution to this important benchmark.

@SamWarmuth @karthikncode @pedramr @ysymyth 