### PR TITLE
Disambiguate Retail Task #109

### DIFF
--- a/tau_bench/envs/retail/tasks.py
+++ b/tau_bench/envs/retail/tasks.py
@@ -2898,7 +2898,7 @@ tasks = [
                 },
             }
         ],
-        "instruction": "You name is Yusuf Gonzalez and your zip code is 91455. You want to return everything but a tablet in a recently delivered order. There is an E-Reader in the order that you want to keep. You want to know how much you can get back.",
+        "instruction": "You name is Yusuf Gonzalez and your zip code is 91455. You want to return everything but a tablet in a recently delivered order. There is an E-Reader in the order that you want to return. You want to know how much you can get back.",
         "outputs": ["346.93"],
         "annotator": 4,
     },

--- a/tau_bench/envs/retail/tasks.py
+++ b/tau_bench/envs/retail/tasks.py
@@ -2898,7 +2898,7 @@ tasks = [
                 },
             }
         ],
-        "instruction": "You name is Yusuf Gonzalez and your zip code is 91455. You want to return everything but a tablet in a recently delivered order. You want to know how much you can get back.",
+        "instruction": "You name is Yusuf Gonzalez and your zip code is 91455. You want to return everything but a tablet in a recently delivered order. There is an E-Reader in the order that you want to keep. You want to know how much you can get back.",
         "outputs": ["346.93"],
         "annotator": 4,
     },


### PR DESCRIPTION
Thank you for a great eval! I think there is some ambiguity in the Retail task at index 109 (with instruction "You name is Yusuf Gonzalez and your zip code is 91455. You want to return everything but a tablet in a recently delivered order. You want to know how much you can get back.")

There are two orders corresponding to this user that contains a Tablet - #W1679211 (intended) and #W2230795 (un-intended). We can disambiguate by updating the user instruction to specify that there's an E-Reader in the one he wants to return. 