### PR TITLE
Add --platform flag to auto error id command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Both of the labels are accompanied with a description.
 To run the auto error identification, run:
 
 ```bash
-python auto_error_identification.py --env <airline/retail> --results-path <the path to your results file here> --max-concurrency 16 --output-path test-auto-error-identification -n 10
+python auto_error_identification.py --env <airline/retail> --platform openai --results-path <the path to your results file here> --max-concurrency 16 --output-path test-auto-error-identification --max-num-failed-results 10
 ```
 
 Please note that this feature utilizes an LLM, which may lead to inaccurate error identifications.


### PR DESCRIPTION
- Platform appears to be a required flag for the auto error identification tool since ab021929.
- Use long form flag in place of `-n` for readability.
- I imagine once this tool is switched to use litellm that the flag will become `--model-provider` for consistency.

Fixes:

```
auto_error_identification.py: error: the following arguments are required: --platform
```