### PR TITLE
added manifest to include wiki.md s

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+recursive-include tau_bench *.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
+recursive-include tau_bench *.json
 recursive-include tau_bench *.md


### PR DESCRIPTION
Installation fails when pip installed without edit mode, added MANIFEST.in to include .md so that the wikis can be imported.