### PR TITLE
provide key detail in retail get_user_details function desc

### DIFF
--- a/tau_bench/envs/retail/tools/get_user_details.py
+++ b/tau_bench/envs/retail/tools/get_user_details.py
@@ -19,7 +19,7 @@ class GetUserDetails(Tool):
             "type": "function",
             "function": {
                 "name": "get_user_details",
-                "description": "Get the details of a user.",
+                "description": "Get the details of a user, including their orders.",
                 "parameters": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
Rows in user table in retail env has Order id ([example](https://github.com/sierra-research/tau-bench/blob/main/tau_bench/envs/retail/data/users.json#L22)), and calling `get_user_details` function to retrieve order ids is a key step in a lot of tests for retail. However the description of function `get_user_details` didn't mention this key details, and the name is not suggestive of that either. This PR fixes that.

Since the user table for airline doesn't have this issue (only has basic user info), I didn't change the description for the same function in that env.