### PR TITLE
provide key detail in airline get_user_details function desc

### DIFF
--- a/tau_bench/envs/airline/tools/get_user_details.py
+++ b/tau_bench/envs/airline/tools/get_user_details.py
@@ -19,7 +19,7 @@ class GetUserDetails(Tool):
             "type": "function",
             "function": {
                 "name": "get_user_details",
-                "description": "Get the details of an user.",
+                "description": "Get the details of an user, including their reservations.",
                 "parameters": {
                     "type": "object",
                     "properties": {


### PR DESCRIPTION
Similar to https://github.com/sierra-research/tau-bench/pull/26, this adds key details in function description for airline env. I missed the fact that some rows have reservation details in the user table for airline env.