### PR TITLE
Litellm retry

### DIFF
--- a/tau_bench/agents/few_shot_agent.py
+++ b/tau_bench/agents/few_shot_agent.py
@@ -2,13 +2,17 @@
 
 import json
 import random
-from litellm import completion
+import logging
+from tau_bench.utils import completion_w_retry
 from typing import List, Optional, Dict, Any
 
 from tau_bench.agents.base import Agent
 from tau_bench.envs.base import Env
 from tau_bench.types import SolveResult, Action, RESPOND_ACTION_NAME
 
+# Setup logging
+logging.basicConfig(format='[%(asctime)s] p%(process)s {%(filename)s:%(lineno)d} %(levelname)s - %(message)s', level=logging.INFO)
+logger = logging.getLogger(__name__)
 
 class FewShotToolCallingAgent(Agent):
     def __init__(
@@ -32,6 +36,8 @@ class FewShotToolCallingAgent(Agent):
         self.few_shot_displays = few_shot_displays
         self.temperature = temperature
         self.num_few_shots = num_few_shots
+        logger.info(f"FewShotToolCallingAgent, model={model}, provider={provider}, temperature={temperature}, num_few_shots{num_few_shots}")
+
     def solve(
         self, env: Env, task_index: Optional[int] = None, max_num_steps: int = 30
     ) -> SolveResult:
@@ -46,8 +52,9 @@ class FewShotToolCallingAgent(Agent):
             {"role": "system", "content": f"{self.wiki}\n\n{few_shots}"},
             {"role": "user", "content": obs},
         ]
-        for _ in range(max_num_steps):
-            res = completion(
+        for i in range(max_num_steps):
+            logger.info(f"solve, i={i}/{max_num_steps}")
+            res = completion_w_retry(
                 messages=messages,
                 model=self.model,
                 custom_llm_provider=self.provider,
@@ -81,6 +88,7 @@ class FewShotToolCallingAgent(Agent):
                     ]
                 )
             if env_response.done:
+                logger.info(f"solve, done at i={i}/{max_num_steps}")
                 break
         return SolveResult(
             reward=reward,

--- a/tau_bench/envs/base.py
+++ b/tau_bench/envs/base.py
@@ -74,7 +74,7 @@ class Env(object):
             user_strategy=user_strategy, model=user_model, provider=user_provider
         )
         self.actions: List[Action] = []
-        self.done = False
+        self.reward = 0
 
     def reset(self, task_index: Optional[int] = None) -> EnvResetResponse:
         if task_index is None:
@@ -93,11 +93,11 @@ class Env(object):
 
         info = EnvInfo(task=self.task)
         reward = 0
-        self.done = False
+        done = False
         if action.name == RESPOND_ACTION_NAME:
             observation = self.user.step(action.kwargs["content"])
             info.source = "user"
-            self.done = "###STOP###" in observation
+            done = "###STOP###" in observation
         elif action.name in self.tools_map:
             try:
                 observation = self.tools_map[action.name].invoke(
@@ -107,17 +107,17 @@ class Env(object):
                 observation = f"Error: {e}"
             info.source = action.name
             if action.name in self.terminate_tools:
-                self.done = True
+                done = True
         else:
             observation = f"Unknown action {action.name}"
             info.source = action.name
-
-        if self.done:
+        if done:
             reward_res = self.calculate_reward()
+            self.reward = reward_res.reward
             reward = reward_res.reward
             info.reward_info = reward_res
             info.user_cost = self.user.get_total_cost()
-        return EnvResponse(observation=observation, reward=reward, done=self.done, info=info)
+        return EnvResponse(observation=observation, reward=reward, done=done, info=info)
 
     def get_data_hash(self) -> str:
         return consistent_hash(to_hashable(self.data))
@@ -128,13 +128,6 @@ class Env(object):
         actions = [
             action for action in self.task.actions if action.name != RESPOND_ACTION_NAME
         ]
-            
-        # Check if user has stopped interaction or terminate action was called
-        if not self.done:
-            print("NOT DONE")
-            reward = 0.0
-        else:
-            print("DONE")   
 
         # Check if the database changes are correct. If they are not correct, then we set the reward to 0.
         # TODO: cache gt_data_hash in tasks.py (low priority)
@@ -146,9 +139,6 @@ class Env(object):
         info = RewardActionInfo(
             r_actions=data_hash == gt_data_hash, gt_data_hash=gt_data_hash
         )
-        
-        # remove gt actions added in the loop above such that we can call calculate_reward() again without side effects
-        self.actions = self.actions[:-len(self.task.actions)]
         
         if not info.r_actions:
             reward = 0.0

--- a/tau_bench/envs/base.py
+++ b/tau_bench/envs/base.py
@@ -127,6 +127,10 @@ class Env(object):
         actions = [
             action for action in self.task.actions if action.name != RESPOND_ACTION_NAME
         ]
+        
+        # if no actions were taken, then the reward is 0
+        if len(self.actions) == 0:
+            reward = 0.0
 
         # Check if the database changes are correct. If they are not correct, then we set the reward to 0.
         # TODO: cache gt_data_hash in tasks.py (low priority)
@@ -138,6 +142,10 @@ class Env(object):
         info = RewardActionInfo(
             r_actions=data_hash == gt_data_hash, gt_data_hash=gt_data_hash
         )
+        
+        # remove gt actions added in the loop above such that we can call calculate_reward() again without side effects
+        self.actions = self.actions[:-len(self.task.actions)]
+        
         if not info.r_actions:
             reward = 0.0
 
@@ -147,6 +155,7 @@ class Env(object):
             outputs = {}
             for output in self.task.outputs:
                 found = False
+                
                 for action in self.actions:
                     if (
                         action.name == RESPOND_ACTION_NAME
@@ -155,6 +164,7 @@ class Env(object):
                     ):
                         found = True
                         break
+                
                 outputs[output] = found
                 if not found:
                     r_outputs = 0.0

--- a/tau_bench/envs/user.py
+++ b/tau_bench/envs/user.py
@@ -319,7 +319,7 @@ class UserStrategy(enum.Enum):
 
 def load_user(
     user_strategy: Union[str, UserStrategy],
-    model: Optional[str] = "gpt-4o",
+    model: Optional[str] = "gpt-4o-2024-08-06",
     provider: Optional[str] = None,
 ) -> BaseUserSimulationEnv:
     if isinstance(user_strategy, str):

--- a/tau_bench/envs/user.py
+++ b/tau_bench/envs/user.py
@@ -2,8 +2,7 @@
 
 import abc
 import enum
-from litellm import completion
-
+from tau_bench.utils import completion_w_retry
 from typing import Optional, List, Dict, Any, Union
 
 
@@ -44,7 +43,7 @@ class LLMUserSimulationEnv(BaseUserSimulationEnv):
         self.reset()
 
     def generate_next_message(self, messages: List[Dict[str, Any]]) -> str:
-        res = completion(
+        res = completion_w_retry(
             model=self.model, custom_llm_provider=self.provider, messages=messages
         )
         message = res.choices[0].message
@@ -115,7 +114,7 @@ User Response:
 <the user response (this will be parsed and sent to the agent)>"""
 
     def generate_next_message(self, messages: List[Dict[str, Any]]) -> str:
-        res = completion(
+        res = completion_w_retry(
             model=self.model, custom_llm_provider=self.provider, messages=messages
         )
         message = res.choices[0].message
@@ -164,7 +163,7 @@ class VerifyUserSimulationEnv(LLMUserSimulationEnv):
         attempts = 0
         cur_message = None
         while attempts < self.max_attempts:
-            res = completion(
+            res = completion_w_retry(
                 model=self.model, custom_llm_provider=self.provider, messages=messages
             )
             cur_message = res.choices[0].message
@@ -224,7 +223,7 @@ Your answer will be parsed, so do not include any other text than the classifica
 -----
 
 Classification:"""
-    res = completion(
+    res = completion_w_retry(
         model=model,
         custom_llm_provider=provider,
         messages=[{"role": "user", "content": prompt}],
@@ -258,7 +257,7 @@ Reflection:
 
 Response:
 <the response (this will be parsed and sent to the agent)>"""
-    res = completion(
+    res = completion_w_retry(
         model=model,
         custom_llm_provider=provider,
         messages=[{"role": "user", "content": prompt}],

--- a/tau_bench/types.py
+++ b/tau_bench/types.py
@@ -33,6 +33,7 @@ class RewardResult(BaseModel):
     reward: float
     info: Union[RewardOutputInfo, RewardActionInfo]
     actions: List[Action]
+    taken_actions: Optional[List[Action]] = None
 
 
 class SolveResult(BaseModel):

--- a/tau_bench/utils.py
+++ b/tau_bench/utils.py
@@ -1,0 +1,120 @@
+"""
+Utility functions for Tau-bench, for example for retrying LLM provider calls.
+"""
+
+# Import required libraries
+import time
+import httpx
+import random
+import litellm
+import functools
+from litellm import completion
+from typing import List, Dict, Any, Tuple, Type
+
+# Decorator function that implements exponential backoff retry logic
+def retry_with_exponential_backoff(
+    max_retries: int = 10,  # Maximum number of retry attempts
+    base_delay: int = 60,  # Initial delay in seconds before the first retry
+    retry_exceptions: Tuple[Type[Exception], ...] = (  # Tuple of exception types that should trigger retries
+        litellm.exceptions.RateLimitError,  # Retry on rate limiting
+        httpx.HTTPStatusError,  # Retry on HTTP errors
+        litellm.llms.bedrock.common_utils.BedrockError,  # Retry on AWS Bedrock specific errors
+        litellm.ServiceUnavailableError,  # Retry when service is unavailable
+        litellm.exceptions.APIConnectionError  # Retry on connection issues
+    )
+):
+    """
+    Creates a decorator that retries a function with exponential backoff when specific exceptions occur.
+    
+    Args:
+        max_retries: Maximum number of retry attempts before giving up
+        base_delay: Initial delay in seconds before the first retry
+        retry_exceptions: Tuple of exception types that should trigger a retry
+    
+    Returns:
+        Decorator function that can be applied to other functions
+    """
+    def decorator(func):
+        """
+        The actual decorator that wraps the target function.
+        
+        Args:
+            func: The function to be wrapped with retry logic
+            
+        Returns:
+            Wrapped function with retry capability
+        """
+        @functools.wraps(func)  # Preserves the metadata of the original function
+        def wrapper(*args, **kwargs):
+            """
+            Wrapper that adds retry logic to the decorated function.
+            
+            Args:
+                *args, **kwargs: Arguments passed to the original function
+                
+            Returns:
+                Result of the successful function call
+                
+            Raises:
+                The last exception encountered if all retries fail
+            """
+            for attempt in range(max_retries):
+                try:
+                    # Attempt to call the original function
+                    return func(*args, **kwargs)
+                except retry_exceptions as e:
+                    # If this is the last attempt, log and re-raise the exception
+                    if attempt == max_retries - 1:
+                        print(f"Rate limit exceeded after {max_retries} attempts: {str(e)}")
+                        raise
+                    
+                    # Calculate delay with exponential backoff and random jitter
+                    # Formula: base_delay * (2^attempt) + random_jitter
+                    delay = base_delay * (2 ** attempt) + random.uniform(0, 0.5)
+                    
+                    # Log the exception and retry information
+                    print(
+                        f"exception={e}, rate limit hit on attempt {attempt+1}/{max_retries}. "
+                        f"Retrying in {delay:.2f} seconds..."
+                    )
+                    
+                    # Wait before next retry
+                    time.sleep(delay)
+                except Exception as e:
+                    # For any unhandled exceptions, log and re-raise without retry
+                    print(f"exception={e}, unhandled exception")
+                    raise
+            
+            # This return statement should never be reached due to the raise in the final attempt
+            # It's included for code completeness
+            return None
+        
+        return wrapper
+    
+    return decorator
+
+# Apply the retry decorator to a function that makes LLM API calls
+@retry_with_exponential_backoff(max_retries=10, base_delay=60)
+def completion_w_retry(
+    model: str,  # The LLM model to use (e.g., "gpt-4", "claude-3")
+    custom_llm_provider: str,  # The provider of the LLM (e.g., "openai", "bedrock")
+    messages: List[Dict[str, Any]], # The conversation messages in the format expected by the API
+    **kwargs
+):
+    """
+    Wrapper function for litellm.completion that adds retry capability.
+    
+    Args:
+        model: The name of the LLM model to use
+        custom_llm_provider: The provider of the LLM service
+        messages: List of message dictionaries in the format expected by the API
+        
+    Returns:
+        The completion response from the LLM provider
+    """
+    return completion(
+        model=model,
+        custom_llm_provider=custom_llm_provider,
+        messages=messages,
+        **kwargs
+    )


### PR DESCRIPTION
Add logic to retry a litellm completion request in case of errors such as RateLimitError. This is especially useful when benchmarking Amazon Bedrock models which have service quota limits that might get breached quickly while testing agents.