### PR TITLE
minor fix: handle none response cost

### DIFF
--- a/tau_bench/agents/tool_calling_agent.py
+++ b/tau_bench/agents/tool_calling_agent.py
@@ -45,7 +45,7 @@ class ToolCallingAgent(Agent):
                 temperature=self.temperature,
             )
             next_message = res.choices[0].message.model_dump()
-            total_cost += res._hidden_params["response_cost"]
+            total_cost += res._hidden_params["response_cost"] or 0
             action = message_to_action(next_message)
             env_response = env.step(action)
             reward = env_response.reward


### PR DESCRIPTION
when running run.py, I've encountered the following error

```
File "tau-bench.git/tau_bench/agents/tool_calling_agent.py", line 48, in solve\n    total_cost += res._hidden_params["response_cost"]\nTypeError: unsupported operand type(s) for +=: \'float\' and \'NoneType\'\n'}
```

To fix this, I am proposing to simply convert None value to 0.