### PR TITLE
Make num_max_steps configurable from the command line script

### DIFF
--- a/run.py
+++ b/run.py
@@ -69,6 +69,7 @@ def parse_args() -> RunConfig:
     parser.add_argument("--shuffle", type=int, default=0)
     parser.add_argument("--user-strategy", type=str, default="llm", choices=[item.value for item in UserStrategy])
     parser.add_argument("--few-shot-displays-path", type=str, help="Path to a jsonlines file containing few shot displays")
+    parser.add_argument("--num-max-steps", type=int, default=30, help="Maximum number of steps to run in solve")
     args = parser.parse_args()
     print(args)
     return RunConfig(
@@ -90,6 +91,7 @@ def parse_args() -> RunConfig:
         shuffle=args.shuffle,
         user_strategy=args.user_strategy,
         few_shot_displays_path=args.few_shot_displays_path,
+        num_max_steps=args.num_max_steps,
     )
 
 

--- a/tau_bench/run.py
+++ b/tau_bench/run.py
@@ -78,6 +78,7 @@ def run(config: RunConfig) -> List[EnvRunResult]:
                 res = agent.solve(
                     env=isolated_env,
                     task_index=idx,
+                    num_max_steps=config.num_max_steps,
                 )
                 result = EnvRunResult(
                     task_id=idx,

--- a/tau_bench/types.py
+++ b/tau_bench/types.py
@@ -88,3 +88,4 @@ class RunConfig(BaseModel):
     shuffle: int = 0
     user_strategy: str = "llm"
     few_shot_displays_path: Optional[str] = None
+    num_max_steps: int = 30


### PR DESCRIPTION
When the agent-user interaction reaches num_max_steps, the trajectory just silently ends without raising an error. For now, it would be great if we could just increase the num_max_steps from the commandline script to run the eval.