### PR TITLE
fix: off-by-one error in random task selection

### DIFF
--- a/tau_bench/envs/base.py
+++ b/tau_bench/envs/base.py
@@ -66,7 +66,7 @@ class Env(object):
         if task_index is not None:
             self.task_index = task_index
         else:
-            self.task_index = random.randint(0, len(tasks))
+            self.task_index = random.randint(0, len(tasks) - 1)
         self.task = tasks[self.task_index]
         self.wiki = wiki
         self.rules = rules
@@ -77,7 +77,7 @@ class Env(object):
 
     def reset(self, task_index: Optional[int] = None) -> EnvResetResponse:
         if task_index is None:
-            task_index = random.randint(0, len(self.tasks))
+            task_index = random.randint(0, len(self.tasks) - 1)
         self.task_index = task_index
         self.data = self.data_load_func()
         self.task = self.tasks[task_index]


### PR DESCRIPTION
## Summary

Fix off-by-one error in random task index selection that causes ~1% of environment initializations to fail with `IndexError: list index out of range`.

## Bug Details

**Location**: `tau_bench/envs/base.py` lines 69 and 80

**Problem**: `random.randint(0, len(tasks))` can return `len(tasks)`, which is an invalid index since valid indices are `0` to `len(tasks)-1`.

**Fix**: Change to `random.randint(0, len(tasks) - 1)` in both `__init__` and `reset()` methods.

## Reproduction

The bug has a probability of `1/(n+1)` where `n` is the number of tasks. With ~100 retail tasks, this is roughly 1% per initialization.

```python
# Simulation shows ~1% failure rate
import random
failures = sum(1 for _ in range(10000) if random.randint(0, 100) >= 100)
print(f"Failure rate: {failures/10000:.2%}")  # ~0.99%
```

## Testing

The fix changes only the random range upper bound. Behavior is otherwise identical.