### PR TITLE
Add per-step timing telemetry (opt-in)

### DIFF
--- a/run.py
+++ b/run.py
@@ -69,6 +69,7 @@ def parse_args() -> RunConfig:
     parser.add_argument("--shuffle", type=int, default=0)
     parser.add_argument("--user-strategy", type=str, default="llm", choices=[item.value for item in UserStrategy])
     parser.add_argument("--few-shot-displays-path", type=str, help="Path to a jsonlines file containing few shot displays")
+    parser.add_argument("--enable-timing", action="store_true", help="Record per-step / sub-step timing telemetry")
     args = parser.parse_args()
     print(args)
     return RunConfig(
@@ -90,6 +91,7 @@ def parse_args() -> RunConfig:
         shuffle=args.shuffle,
         user_strategy=args.user_strategy,
         few_shot_displays_path=args.few_shot_displays_path,
+        enable_timing=args.enable_timing,
     )
 
 

--- a/tau_bench/agents/tool_calling_agent.py
+++ b/tau_bench/agents/tool_calling_agent.py
@@ -28,6 +28,7 @@ class ToolCallingAgent(Agent):
         self, env: Env, task_index: Optional[int] = None, max_num_steps: int = 30
     ) -> SolveResult:
         total_cost = 0.0
+        recorder = getattr(env, "timing_recorder", None)
         env_reset_res = env.reset(task_index=task_index)
         obs = env_reset_res.observation
         info = env_reset_res.info.model_dump()
@@ -36,14 +37,27 @@ class ToolCallingAgent(Agent):
             {"role": "system", "content": self.wiki},
             {"role": "user", "content": obs},
         ]
-        for _ in range(max_num_steps):
-            res = completion(
-                messages=messages,
-                model=self.model,
-                custom_llm_provider=self.provider,
-                tools=self.tools_info,
-                temperature=self.temperature,
-            )
+        for step_index in range(max_num_steps):
+            if recorder is not None:
+                recorder.begin_step(step_index)
+                from tau_bench.timing import SpanKind
+
+                with recorder.span(SpanKind.AGENT_LLM, "agent"):
+                    res = completion(
+                        messages=messages,
+                        model=self.model,
+                        custom_llm_provider=self.provider,
+                        tools=self.tools_info,
+                        temperature=self.temperature,
+                    )
+            else:
+                res = completion(
+                    messages=messages,
+                    model=self.model,
+                    custom_llm_provider=self.provider,
+                    tools=self.tools_info,
+                    temperature=self.temperature,
+                )
             next_message = res.choices[0].message.model_dump()
             total_cost += res._hidden_params["response_cost"] or 0
             action = message_to_action(next_message)
@@ -77,6 +91,7 @@ class ToolCallingAgent(Agent):
             info=info,
             messages=messages,
             total_cost=total_cost,
+            timing=recorder.report() if recorder is not None else None,
         )
 
 

--- a/tau_bench/envs/base.py
+++ b/tau_bench/envs/base.py
@@ -74,6 +74,14 @@ class Env(object):
             user_strategy=user_strategy, model=user_model, provider=user_provider
         )
         self.actions: List[Action] = []
+        # Optional timing recorder; when None, all timing is a no-op and
+        # behavior is bit-identical to upstream.
+        self.timing_recorder = None
+
+    def attach_timing(self, recorder) -> None:
+        """Wire a shared TimingRecorder into the env. User-sim calls are timed
+        at the env boundary, so every user strategy is covered uniformly."""
+        self.timing_recorder = recorder
 
     def reset(self, task_index: Optional[int] = None) -> EnvResetResponse:
         if task_index is None:
@@ -82,7 +90,13 @@ class Env(object):
         self.data = self.data_load_func()
         self.task = self.tasks[task_index]
         self.actions = []
-        initial_observation = self.user.reset(instruction=self.task.instruction)
+        if self.timing_recorder is not None:
+            from tau_bench.timing import SpanKind
+
+            with self.timing_recorder.span(SpanKind.USER_LLM, "user"):
+                initial_observation = self.user.reset(instruction=self.task.instruction)
+        else:
+            initial_observation = self.user.reset(instruction=self.task.instruction)
         return EnvResetResponse(
             observation=initial_observation, info=EnvInfo(task=self.task, source="user")
         )
@@ -94,14 +108,28 @@ class Env(object):
         reward = 0
         done = False
         if action.name == RESPOND_ACTION_NAME:
-            observation = self.user.step(action.kwargs["content"])
+            if self.timing_recorder is not None:
+                from tau_bench.timing import SpanKind
+
+                with self.timing_recorder.span(SpanKind.USER_LLM, "user"):
+                    observation = self.user.step(action.kwargs["content"])
+            else:
+                observation = self.user.step(action.kwargs["content"])
             info.source = "user"
             done = "###STOP###" in observation
         elif action.name in self.tools_map:
             try:
-                observation = self.tools_map[action.name].invoke(
-                    data=self.data, **action.kwargs
-                )
+                if self.timing_recorder is not None:
+                    from tau_bench.timing import SpanKind
+
+                    with self.timing_recorder.span(SpanKind.TOOL_EXEC, action.name):
+                        observation = self.tools_map[action.name].invoke(
+                            data=self.data, **action.kwargs
+                        )
+                else:
+                    observation = self.tools_map[action.name].invoke(
+                        data=self.data, **action.kwargs
+                    )
             except Exception as e:
                 observation = f"Error: {e}"
             info.source = action.name
@@ -131,9 +159,17 @@ class Env(object):
         # Check if the database changes are correct. If they are not correct, then we set the reward to 0.
         # TODO: cache gt_data_hash in tasks.py (low priority)
         self.data = self.data_load_func()
-        for action in self.task.actions:
-            if action.name not in self.terminate_tools:
-                self.step(action)
+        # Reward replay re-invokes GT actions via self.step(); suspend timing so
+        # those invokes are never counted as trajectory time.
+        if self.timing_recorder is not None:
+            with self.timing_recorder.suspend():
+                for action in self.task.actions:
+                    if action.name not in self.terminate_tools:
+                        self.step(action)
+        else:
+            for action in self.task.actions:
+                if action.name not in self.terminate_tools:
+                    self.step(action)
         gt_data_hash = self.get_data_hash()
         info = RewardActionInfo(
             r_actions=data_hash == gt_data_hash, gt_data_hash=gt_data_hash

--- a/tau_bench/run.py
+++ b/tau_bench/run.py
@@ -72,6 +72,10 @@ def run(config: RunConfig) -> List[EnvRunResult]:
                 user_provider=config.user_model_provider,
                 task_index=idx,
             )
+            if config.enable_timing:
+                from tau_bench.timing import TimingRecorder
+
+                isolated_env.attach_timing(TimingRecorder(source="live"))
 
             print(f"Running task {idx}")
             try:
@@ -85,6 +89,7 @@ def run(config: RunConfig) -> List[EnvRunResult]:
                     info=res.info,
                     traj=res.messages,
                     trial=i,
+                    timing=res.timing,
                 )
             except Exception as e:
                 result = EnvRunResult(

--- a/tau_bench/timing.py
+++ b/tau_bench/timing.py
@@ -1,0 +1,156 @@
+# Copyright Sierra
+
+"""Shared timing telemetry core for tau-bench.
+
+This module is the single source of truth for *how* timing is recorded and
+aggregated. It is consumed by two drivers that MUST produce identical
+telemetry (same schema, same span kinds, same step aggregation):
+
+  * the live run loop  -> records wall-clock latency of real LLM/tool calls
+  * the replay-graft loop -> records timing while replaying a recorded
+    trajectory (shadow-timed LLM calls, real tool execution)
+
+The only fields that legitimately differ between the two are ``source``
+("live" vs "replay") and the measured durations. Everything structural
+(span kinds, names, step grouping) is produced by this shared code, so a
+report cannot tell you which driver made it except via ``source``.
+
+When no recorder is attached, all instrumentation is a no-op and upstream
+behavior is bit-identical.
+"""
+
+from __future__ import annotations
+
+import time
+from contextlib import contextmanager
+from typing import Callable, Iterator, List, Optional
+
+from tau_bench.types import StepTiming, TimingReport, TimingSpan
+
+
+class SpanKind:
+    """Canonical sub-step span kinds. Shared by both drivers."""
+
+    AGENT_LLM = "agent_llm"  # one agent completion() call
+    TOOL_EXEC = "tool_exec"  # one env tool .invoke()
+    USER_LLM = "user_llm"  # one user-simulator completion() call
+
+
+class TimingRecorder:
+    """Collects timing spans and aggregates them into a TimingReport.
+
+    The driver sets the current step via ``begin_step`` and wraps each timed
+    operation in ``span``. Env / user code records spans against whatever the
+    current step is, so they don't need to know step numbers.
+    """
+
+    def __init__(
+        self,
+        source: str = "live",
+        clock: Callable[[], float] = time.perf_counter,
+    ) -> None:
+        self.source = source
+        self._clock = clock
+        self._t0: Optional[float] = None
+        self._seq = 0
+        self.current_step = -1
+        self.spans: List[TimingSpan] = []
+        # Disables tool spans while Env.calculate_reward replays GT actions,
+        # so reward-replay tool invokes are never counted as trajectory time.
+        self.suspended = False
+
+    def start(self) -> None:
+        if self._t0 is None:
+            self._t0 = self._clock()
+
+    def begin_step(self, step_index: int) -> None:
+        self.start()
+        self.current_step = step_index
+
+    @contextmanager
+    def span(self, kind: str, name: str) -> Iterator[None]:
+        if self.suspended:
+            yield
+            return
+        self.start()
+        assert self._t0 is not None
+        t_start = self._clock()
+        try:
+            yield
+        finally:
+            t_end = self._clock()
+            self.spans.append(
+                TimingSpan(
+                    kind=kind,
+                    name=name,
+                    step_index=self.current_step,
+                    seq=self._seq,
+                    wall_offset_ms=(t_start - self._t0) * 1000.0,
+                    duration_ms=(t_end - t_start) * 1000.0,
+                    source=self.source,
+                )
+            )
+            self._seq += 1
+
+    @contextmanager
+    def suspend(self) -> Iterator[None]:
+        """Temporarily stop recording (used during reward replay)."""
+        prev = self.suspended
+        self.suspended = True
+        try:
+            yield
+        finally:
+            self.suspended = prev
+
+    def report(self) -> TimingReport:
+        return build_report(self.spans, self.source)
+
+
+def build_report(spans: List[TimingSpan], source: str) -> TimingReport:
+    """Aggregate flat spans into per-step rollups and grand totals.
+
+    This is intentionally a free function so both drivers (and tests) reduce
+    spans the exact same way.
+    """
+    by_step: dict[int, List[TimingSpan]] = {}
+    for s in spans:
+        by_step.setdefault(s.step_index, []).append(s)
+
+    steps: List[StepTiming] = []
+    for step_index in sorted(by_step):
+        step_spans = sorted(by_step[step_index], key=lambda s: s.seq)
+        agent_ms = sum(s.duration_ms for s in step_spans if s.kind == SpanKind.AGENT_LLM)
+        tool_ms = sum(s.duration_ms for s in step_spans if s.kind == SpanKind.TOOL_EXEC)
+        user_ms = sum(s.duration_ms for s in step_spans if s.kind == SpanKind.USER_LLM)
+        first_start = min(s.wall_offset_ms for s in step_spans)
+        last_end = max(s.wall_offset_ms + s.duration_ms for s in step_spans)
+        steps.append(
+            StepTiming(
+                step_index=step_index,
+                agent_llm_ms=agent_ms,
+                tool_ms=tool_ms,
+                user_llm_ms=user_ms,
+                step_ms=last_end - first_start,
+                spans=step_spans,
+            )
+        )
+
+    total_agent = sum(st.agent_llm_ms for st in steps)
+    total_tool = sum(st.tool_ms for st in steps)
+    total_user = sum(st.user_llm_ms for st in steps)
+    if spans:
+        total_ms = max(s.wall_offset_ms + s.duration_ms for s in spans) - min(
+            s.wall_offset_ms for s in spans
+        )
+    else:
+        total_ms = 0.0
+    return TimingReport(
+        source=source,
+        total_ms=total_ms,
+        agent_llm_ms=total_agent,
+        tool_ms=total_tool,
+        user_llm_ms=total_user,
+        n_steps=len(steps),
+        steps=steps,
+        spans=sorted(spans, key=lambda s: s.seq),
+    )

--- a/tau_bench/types.py
+++ b/tau_bench/types.py
@@ -35,11 +35,48 @@ class RewardResult(BaseModel):
     actions: List[Action]
 
 
+class TimingSpan(BaseModel):
+    """A single timed sub-step. Shared by the live and replay-graft drivers."""
+
+    kind: str  # one of tau_bench.timing.SpanKind
+    name: str  # tool name, or "agent" / "user"
+    step_index: int
+    seq: int
+    wall_offset_ms: float
+    duration_ms: float
+    source: str = "live"  # "live" or "replay"
+
+
+class StepTiming(BaseModel):
+    """Per-step rollup of the sub-step spans belonging to one agent step."""
+
+    step_index: int
+    agent_llm_ms: float = 0.0
+    tool_ms: float = 0.0
+    user_llm_ms: float = 0.0
+    step_ms: float = 0.0
+    spans: List[TimingSpan] = []
+
+
+class TimingReport(BaseModel):
+    """Full timing telemetry for a single solved task."""
+
+    source: str  # "live" or "replay"
+    total_ms: float
+    agent_llm_ms: float
+    tool_ms: float
+    user_llm_ms: float
+    n_steps: int
+    steps: List[StepTiming] = []
+    spans: List[TimingSpan] = []
+
+
 class SolveResult(BaseModel):
     reward: float
     messages: List[Dict[str, Any]]
     info: Dict[str, Any]
     total_cost: Optional[float] = None
+    timing: Optional[TimingReport] = None
 
 
 class EnvInfo(BaseModel):
@@ -67,6 +104,7 @@ class EnvRunResult(BaseModel):
     info: Dict[str, Any]
     traj: List[Dict[str, Any]]
     trial: int
+    timing: Optional[TimingReport] = None
 
 
 class RunConfig(BaseModel):
@@ -88,3 +126,4 @@ class RunConfig(BaseModel):
     shuffle: int = 0
     user_strategy: str = "llm"
     few_shot_displays_path: Optional[str] = None
+    enable_timing: bool = False

--- a/tests/test_timing.py
+++ b/tests/test_timing.py
@@ -1,0 +1,119 @@
+# Copyright Sierra
+
+"""Schema-invariant tests for the shared timing core.
+
+These guard the core guarantee behind the two timing drivers: a live report
+and a replay-graft report produced from the same sequence of spans must be
+structurally indistinguishable -- identical span kinds, names, step grouping,
+and aggregation. The ONLY field allowed to differ is ``source``.
+"""
+
+import itertools
+
+from tau_bench.timing import SpanKind, TimingRecorder, build_report
+from tau_bench.types import TimingReport
+
+
+class FakeClock:
+    """Deterministic monotonic clock: each call advances by a fixed step."""
+
+    def __init__(self, step: float = 0.1):
+        self._t = 0.0
+        self._step = step
+
+    def __call__(self) -> float:
+        t = self._t
+        self._t += self._step
+        return t
+
+
+def _record_canonical_trajectory(source: str) -> TimingReport:
+    """Drive the SAME canonical op sequence through a recorder.
+
+    Sequence mirrors a tiny tau-bench task:
+      step -1: user (initial)
+      step 0 : agent -> tool
+      step 1 : agent -> user (respond)
+    """
+    rec = TimingRecorder(source=source, clock=FakeClock(step=0.05))
+    rec.begin_step(-1)
+    with rec.span(SpanKind.USER_LLM, "user"):
+        pass
+    rec.begin_step(0)
+    with rec.span(SpanKind.AGENT_LLM, "agent"):
+        pass
+    with rec.span(SpanKind.TOOL_EXEC, "find_user_id_by_email"):
+        pass
+    rec.begin_step(1)
+    with rec.span(SpanKind.AGENT_LLM, "agent"):
+        pass
+    with rec.span(SpanKind.USER_LLM, "user"):
+        pass
+    return rec.report()
+
+
+def _structural_signature(report: TimingReport):
+    """Everything about a report EXCEPT the measured durations and source."""
+    return {
+        "n_steps": report.n_steps,
+        "steps": [
+            (
+                st.step_index,
+                tuple((s.kind, s.name, s.step_index, s.seq) for s in st.spans),
+            )
+            for st in report.steps
+        ],
+        "spans": [(s.kind, s.name, s.step_index, s.seq) for s in report.spans],
+    }
+
+
+def test_live_and_replay_reports_are_structurally_identical():
+    live = _record_canonical_trajectory("live")
+    replay = _record_canonical_trajectory("replay")
+    # Only the source label may differ.
+    assert live.source == "live"
+    assert replay.source == "replay"
+    assert _structural_signature(live) == _structural_signature(replay)
+
+
+def test_report_schema_fields():
+    report = _record_canonical_trajectory("live")
+    # Step rollups + grand totals are present and self-consistent.
+    assert report.n_steps == 3  # steps -1, 0, 1
+    assert report.agent_llm_ms == sum(st.agent_llm_ms for st in report.steps)
+    assert report.tool_ms == sum(st.tool_ms for st in report.steps)
+    assert report.user_llm_ms == sum(st.user_llm_ms for st in report.steps)
+    # Every span carries the report's source.
+    assert all(s.source == report.source for s in report.spans)
+    # Spans are globally ordered by seq.
+    seqs = [s.seq for s in report.spans]
+    assert seqs == sorted(seqs)
+
+
+def test_spans_grouped_by_step():
+    report = _record_canonical_trajectory("replay")
+    by_step = {st.step_index: st for st in report.steps}
+    assert set(by_step) == {-1, 0, 1}
+    # step 0 has exactly one agent_llm and one tool_exec span.
+    kinds_step0 = sorted(s.kind for s in by_step[0].spans)
+    assert kinds_step0 == [SpanKind.AGENT_LLM, SpanKind.TOOL_EXEC]
+
+
+def test_suspend_drops_spans():
+    rec = TimingRecorder(source="replay", clock=FakeClock())
+    rec.begin_step(0)
+    with rec.suspend():
+        with rec.span(SpanKind.TOOL_EXEC, "reward_replay_tool"):
+            pass
+    with rec.span(SpanKind.AGENT_LLM, "agent"):
+        pass
+    report = rec.report()
+    assert all(s.name != "reward_replay_tool" for s in report.spans)
+    assert len(report.spans) == 1
+
+
+def test_empty_recorder_is_safe():
+    report = build_report([], "live")
+    assert report.n_steps == 0
+    assert report.total_ms == 0.0
+    assert report.spans == []

--- a/tests/test_timing_e2e.py
+++ b/tests/test_timing_e2e.py
@@ -1,0 +1,131 @@
+# Copyright Sierra
+"""End-to-end smoke test for live `--enable-timing` wiring.
+
+Unlike test_timing.py (which exercises the timing core in isolation), this test
+drives the *real* run loop: a real retail Env + ToolCallingAgent, with only the
+network LLM calls stubbed out. It verifies that attaching a TimingRecorder makes
+agent.solve() produce a populated TimingReport whose spans cover all three span
+kinds, are grouped by step, and roll up consistently.
+"""
+import json
+from unittest.mock import patch
+
+from tau_bench.envs import get_env
+from tau_bench.agents.tool_calling_agent import ToolCallingAgent
+from tau_bench.timing import SpanKind, TimingRecorder
+
+
+class _FakeMessage:
+    def __init__(self, content=None, tool_calls=None):
+        self.content = content
+        self._tool_calls = tool_calls
+
+    def model_dump(self):
+        return {
+            "role": "assistant",
+            "content": self.content,
+            "tool_calls": self._tool_calls,
+        }
+
+
+class _FakeResponse:
+    def __init__(self, message, cost=0.0):
+        self.choices = [type("Choice", (), {"message": message})()]
+        self._hidden_params = {"response_cost": cost}
+
+
+def _tool_call_message(name, arguments):
+    return _FakeMessage(
+        content=None,
+        tool_calls=[
+            {
+                "id": "call_1",
+                "type": "function",
+                "function": {"name": name, "arguments": json.dumps(arguments)},
+            }
+        ],
+    )
+
+
+def test_live_timing_end_to_end_smoke():
+    # Scripted agent: step 0 calls a pure tool, step 1 responds (ends dialog).
+    agent_script = iter(
+        [
+            _tool_call_message("calculate", {"expression": "2 + 2"}),
+            _FakeMessage(content="The answer is 4. Anything else?"),
+        ]
+    )
+
+    def fake_agent_completion(*args, **kwargs):
+        return _FakeResponse(next(agent_script))
+
+    # User sim always ends the conversation; ###STOP### marks the run done.
+    def fake_user_completion(*args, **kwargs):
+        return _FakeResponse(_FakeMessage(content="Thanks, that's all. ###STOP###"))
+
+    with patch(
+        "tau_bench.envs.user.completion", side_effect=fake_user_completion
+    ), patch(
+        "tau_bench.agents.tool_calling_agent.completion",
+        side_effect=fake_agent_completion,
+    ):
+        env = get_env(
+            "retail",
+            user_strategy="llm",
+            user_model="gpt-4o",
+            task_split="test",
+            user_provider="openai",
+            task_index=0,
+        )
+        env.attach_timing(TimingRecorder(source="live"))
+        agent = ToolCallingAgent(
+            tools_info=env.tools_info,
+            wiki=env.wiki,
+            model="gpt-4o",
+            provider="openai",
+            temperature=0.0,
+        )
+        result = agent.solve(env=env, task_index=0, max_num_steps=5)
+
+    timing = result.timing
+    assert timing is not None, "live run with recorder must populate SolveResult.timing"
+    assert timing.source == "live"
+
+    # Steps: -1 (initial user message from env.reset), 0 (tool), 1 (respond).
+    assert timing.n_steps == 3
+    assert {s.step_index for s in timing.spans} == {-1, 0, 1}
+    kinds = {s.kind for s in timing.spans}
+    assert kinds == {SpanKind.AGENT_LLM, SpanKind.TOOL_EXEC, SpanKind.USER_LLM}
+
+    # One agent call per real step (2); one tool exec; two user-sim calls
+    # (the initial reset greeting at step -1, and the reply to the agent's
+    # respond at step 1).
+    by_kind = {}
+    for s in timing.spans:
+        by_kind.setdefault(s.kind, []).append(s)
+    assert len(by_kind[SpanKind.AGENT_LLM]) == 2
+    assert len(by_kind[SpanKind.TOOL_EXEC]) == 1
+    assert len(by_kind[SpanKind.USER_LLM]) == 2
+    assert by_kind[SpanKind.TOOL_EXEC][0].name == "calculate"
+
+    # Grand totals equal the span-level aggregation per kind.
+    assert abs(
+        timing.agent_llm_ms
+        - sum(s.duration_ms for s in by_kind[SpanKind.AGENT_LLM])
+    ) < 1e-6
+    assert abs(
+        timing.tool_ms - sum(s.duration_ms for s in by_kind[SpanKind.TOOL_EXEC])
+    ) < 1e-6
+    assert abs(
+        timing.user_llm_ms
+        - sum(s.duration_ms for s in by_kind[SpanKind.USER_LLM])
+    ) < 1e-6
+
+    # Per-step rollups are non-negative and bounded by the wall-clock total.
+    for step in timing.steps:
+        assert step.step_ms >= 0
+        assert step.agent_llm_ms >= 0
+        assert step.tool_ms >= 0
+        assert step.user_llm_ms >= 0
+        assert step.step_ms <= timing.total_ms + 1e-6
+    assert timing.total_ms >= 0


### PR DESCRIPTION
## Summary
Adds **opt-in** per-step execution timing to tau-bench runs via a new `--enable-timing` flag. Off by default — zero behavior change unless explicitly enabled.

When enabled, each run records spans for agent LLM calls, tool execution, and user-simulator LLM calls, aggregated per step and rolled up to grand totals, and attached to `SolveResult.timing` / `EnvRunResult.timing`.

## What's included
- `tau_bench/timing.py` — shared timing core (`TimingRecorder`, `build_report`) used as the single source of truth.
- `tau_bench/types.py` — `TimingSpan`, `StepTiming`, `TimingReport` schema; `RunConfig.enable_timing`.
- Live instrumentation in `envs/base.py`, `agents/tool_calling_agent.py`, `run.py`, top-level `run.py` (`--enable-timing`).
- `tests/test_timing.py` — schema-invariant tests (no network; deterministic clock).

## Design notes
- Recording during ground-truth action replay in `calculate_reward` is suspended so reward computation never pollutes timing.
- The report schema is intentionally driver-agnostic so an alternative measurement path produces an identical report (see companion PR).

## Testing
`pytest tests/test_timing.py -q` → 5 passed.

## How to verify (≈5s, no network)
```bash
pip install -e . && PYTHONPATH=. pytest tests/test_timing.py tests/test_timing_e2e.py -q
```
Result on this branch: **6 passed**. The e2e test drives the real retail `Env` + `ToolCallingAgent` with only the LLM calls stubbed, so it exercises the live instrumentation path end-to-end without any API keys.