### PR TITLE
Fix user-sim cost accumulation; clarify --seed semantics

### DIFF
--- a/run.py
+++ b/run.py
@@ -65,7 +65,7 @@ def parse_args() -> RunConfig:
         default=1,
         help="Number of tasks to run in parallel",
     )
-    parser.add_argument("--seed", type=int, default=10)
+    parser.add_argument("--seed", type=int, default=10, help="Seed for task-order shuffling only; it is NOT passed to the LLM completion calls, so it does not make agent/user generations deterministic")
     parser.add_argument("--shuffle", type=int, default=0)
     parser.add_argument("--user-strategy", type=str, default="llm", choices=[item.value for item in UserStrategy])
     parser.add_argument("--few-shot-displays-path", type=str, help="Path to a jsonlines file containing few shot displays")

--- a/tau_bench/envs/user.py
+++ b/tau_bench/envs/user.py
@@ -49,7 +49,9 @@ class LLMUserSimulationEnv(BaseUserSimulationEnv):
         )
         message = res.choices[0].message
         self.messages.append(message.model_dump())
-        self.total_cost = res._hidden_params["response_cost"]
+        # Accumulate across turns; assigning here under-reported the user-sim
+        # cost as only the most recent turn.
+        self.total_cost += res._hidden_params["response_cost"] or 0
         return message.content
 
     def build_system_prompt(self, instruction: Optional[str]) -> str:
@@ -120,7 +122,8 @@ User Response:
         )
         message = res.choices[0].message
         self.messages.append(message.model_dump())
-        self.total_cost = res._hidden_params["response_cost"]
+        # Accumulate across turns; see LLMUserSimulationEnv note.
+        self.total_cost += res._hidden_params["response_cost"] or 0
         return self.parse_response(message.content)
 
     def reset(self, instruction: Optional[str] = None) -> str:
@@ -158,6 +161,7 @@ class VerifyUserSimulationEnv(LLMUserSimulationEnv):
         self.model = model
         self.provider = provider
         self.max_attempts = max_attempts
+        self.total_cost = 0.0
         self.reset()
 
     def generate_next_message(self, messages: List[Dict[str, Any]]) -> str:
@@ -168,7 +172,8 @@ class VerifyUserSimulationEnv(LLMUserSimulationEnv):
                 model=self.model, custom_llm_provider=self.provider, messages=messages
             )
             cur_message = res.choices[0].message
-            self.total_cost = res._hidden_params["response_cost"]
+            # Accumulate across verification retries and turns.
+            self.total_cost += res._hidden_params["response_cost"] or 0
             if verify(self.model, self.provider, cur_message, messages):
                 self.messages.append(cur_message.model_dump())
                 return cur_message.content


### PR DESCRIPTION
## Summary
Two small, non-behavioral fixes (no effect on rewards, trajectories, or task outcomes).

### 1. `fix(user-sim)`: accumulate user-sim cost instead of overwriting
`generate_next_message` did `self.total_cost = <this turn's cost>`, so `get_total_cost()` / `EnvRunResult.info.user_cost` reported only the **last** turn's cost. In `VerifyUserSimulationEnv` it also discarded the cost of every verification retry. Changed to `+=` across all three user-sim subclasses, initialized `total_cost` in `VerifyUserSimulationEnv` (previously unset — would raise under `+=`), and guarded a `None` `response_cost` with `or 0`.

### 2. `docs(run)`: clarify `--seed`
`--seed` only shuffles task order; it is never forwarded to LLM completion calls, so it does not make generations deterministic. Updated the argparse help text to prevent the common misconception.

Two separate commits.

## Related issues
- Relates to #57 (High Variance in final accuracy) — the `--seed` help-text fix documents that the seed only shuffles task order and is **not** forwarded to LLM calls, addressing a common source of the determinism confusion raised there.
- Extends #64 (handle none response cost, merged) — same lines in `tau_bench/envs/user.py`; keeps its `or 0` none-guard and additionally fixes the per-turn cost overwrite.