### PR TITLE
Opt-in reward-precision fixes (strict output match + data preserve)

### DIFF
--- a/run.py
+++ b/run.py
@@ -69,6 +69,19 @@ def parse_args() -> RunConfig:
     parser.add_argument("--shuffle", type=int, default=0)
     parser.add_argument("--user-strategy", type=str, default="llm", choices=[item.value for item in UserStrategy])
     parser.add_argument("--few-shot-displays-path", type=str, help="Path to a jsonlines file containing few shot displays")
+    parser.add_argument(
+        "--strict-output-match",
+        action="store_true",
+        help="Require whole-token matches for required task outputs in reward "
+        "checking (a required output of '10' no longer matches '100'). Off by "
+        "default; default scoring is unchanged.",
+    )
+    parser.add_argument(
+        "--preserve-data-on-reward",
+        action="store_true",
+        help="Leave the env holding the agent's final data state after reward "
+        "computation, instead of the ground-truth replay state. Off by default.",
+    )
     args = parser.parse_args()
     print(args)
     return RunConfig(
@@ -90,6 +103,8 @@ def parse_args() -> RunConfig:
         shuffle=args.shuffle,
         user_strategy=args.user_strategy,
         few_shot_displays_path=args.few_shot_displays_path,
+        strict_output_match=args.strict_output_match,
+        preserve_data_on_reward=args.preserve_data_on_reward,
     )
 
 

--- a/tau_bench/envs/__init__.py
+++ b/tau_bench/envs/__init__.py
@@ -12,6 +12,8 @@ def get_env(
     task_split: str,
     user_provider: Optional[str] = None,
     task_index: Optional[int] = None,
+    strict_output_match: Optional[bool] = None,
+    preserve_data_on_reward: Optional[bool] = None,
 ) -> Env:
     if env_name == "retail":
         from tau_bench.envs.retail import MockRetailDomainEnv
@@ -22,6 +24,8 @@ def get_env(
             task_split=task_split,
             user_provider=user_provider,
             task_index=task_index,
+            strict_output_match=strict_output_match,
+            preserve_data_on_reward=preserve_data_on_reward,
         )
     elif env_name == "airline":
         from tau_bench.envs.airline import MockAirlineDomainEnv
@@ -32,6 +36,8 @@ def get_env(
             task_split=task_split,
             user_provider=user_provider,
             task_index=task_index,
+            strict_output_match=strict_output_match,
+            preserve_data_on_reward=preserve_data_on_reward,
         )
     else:
         raise ValueError(f"Unknown environment: {env_name}")

--- a/tau_bench/envs/airline/env.py
+++ b/tau_bench/envs/airline/env.py
@@ -17,6 +17,8 @@ class MockAirlineDomainEnv(Env):
         user_provider: Optional[str] = None,
         task_split: str = "test",
         task_index: Optional[int] = None,
+        strict_output_match: Optional[bool] = None,
+        preserve_data_on_reward: Optional[bool] = None,
     ):
         match task_split:
             case "test":
@@ -33,5 +35,7 @@ class MockAirlineDomainEnv(Env):
             user_model=user_model,
             user_provider=user_provider,
             task_index=task_index,
+            strict_output_match=strict_output_match,
+            preserve_data_on_reward=preserve_data_on_reward,
         )
         self.terminate_tools = ["transfer_to_human_agents"]

--- a/tau_bench/envs/base.py
+++ b/tau_bench/envs/base.py
@@ -1,6 +1,8 @@
 # Copyright Sierra
 
+import os
 import random
+import re
 from hashlib import sha256
 from tau_bench.envs.tool import Tool
 from typing import Any, Callable, Dict, List, Type, Optional, Set, Union, Tuple
@@ -41,6 +43,24 @@ def consistent_hash(
     return sha256(str(value).encode("utf-8")).hexdigest()
 
 
+def output_matches(output: str, content: str, strict: bool = False) -> bool:
+    """Whether a required task output is present in an agent reply.
+
+    Default (``strict=False``) preserves upstream behaviour: a case-insensitive,
+    comma-stripped substring test. With ``strict=True`` the match is anchored to
+    token boundaries, so a required output of ``"10"`` is no longer satisfied by
+    ``"100"`` (or any longer number/word) appearing in the reply.
+    """
+    content = content.lower().replace(",", "")
+    needle = output.lower()
+    if strict:
+        return (
+            re.search(r"(?<!\w)" + re.escape(needle) + r"(?!\w)", content)
+            is not None
+        )
+    return needle in content
+
+
 class Env(object):
     def __init__(
         self,
@@ -74,6 +94,18 @@ class Env(object):
             user_strategy=user_strategy, model=user_model, provider=user_provider
         )
         self.actions: List[Action] = []
+        # Opt-in reward-precision flags. Both default OFF so scoring is
+        # byte-identical to upstream unless explicitly enabled.
+        #   TAU_STRICT_OUTPUT_MATCH=1  -> require whole-token output matches
+        #       instead of a bare substring test (avoids e.g. required output
+        #       "10" being satisfied by "100" anywhere in the agent's reply).
+        #   TAU_PRESERVE_DATA_ON_REWARD=1 -> restore self.data after the
+        #       ground-truth action replay in calculate_reward, so the env is
+        #       left holding the agent's final state rather than the GT state.
+        self.strict_output_match = os.getenv("TAU_STRICT_OUTPUT_MATCH") == "1"
+        self.preserve_data_on_reward = (
+            os.getenv("TAU_PRESERVE_DATA_ON_REWARD") == "1"
+        )
 
     def reset(self, task_index: Optional[int] = None) -> EnvResetResponse:
         if task_index is None:
@@ -130,11 +162,16 @@ class Env(object):
 
         # Check if the database changes are correct. If they are not correct, then we set the reward to 0.
         # TODO: cache gt_data_hash in tasks.py (low priority)
+        agent_data = self.data
         self.data = self.data_load_func()
         for action in self.task.actions:
             if action.name not in self.terminate_tools:
                 self.step(action)
         gt_data_hash = self.get_data_hash()
+        if self.preserve_data_on_reward:
+            # Leave the env holding the agent's final state, not the GT replay
+            # state, so callers can inspect post-reward without surprise.
+            self.data = agent_data
         info = RewardActionInfo(
             r_actions=data_hash == gt_data_hash, gt_data_hash=gt_data_hash
         )
@@ -148,10 +185,12 @@ class Env(object):
             for output in self.task.outputs:
                 found = False
                 for action in self.actions:
-                    if (
-                        action.name == RESPOND_ACTION_NAME
-                        and output.lower()
-                        in action.kwargs["content"].lower().replace(",", "")
+                    if action.name != RESPOND_ACTION_NAME:
+                        continue
+                    if output_matches(
+                        output,
+                        action.kwargs["content"],
+                        strict=self.strict_output_match,
                     ):
                         found = True
                         break

--- a/tau_bench/envs/base.py
+++ b/tau_bench/envs/base.py
@@ -73,6 +73,8 @@ class Env(object):
         user_model: str,
         user_provider: Optional[str] = None,
         task_index: Optional[int] = None,
+        strict_output_match: Optional[bool] = None,
+        preserve_data_on_reward: Optional[bool] = None,
     ) -> None:
         super().__init__()
         self.data_load_func = data_load_func
@@ -95,17 +97,24 @@ class Env(object):
         )
         self.actions: List[Action] = []
         # Opt-in reward-precision flags. Both default OFF so scoring is
-        # byte-identical to upstream unless explicitly enabled.
-        #   TAU_STRICT_OUTPUT_MATCH=1  -> require whole-token output matches
-        #       instead of a bare substring test (avoids e.g. required output
-        #       "10" being satisfied by "100" anywhere in the agent's reply).
-        #   TAU_PRESERVE_DATA_ON_REWARD=1 -> restore self.data after the
-        #       ground-truth action replay in calculate_reward, so the env is
-        #       left holding the agent's final state rather than the GT state.
-        self.strict_output_match = os.getenv("TAU_STRICT_OUTPUT_MATCH") == "1"
-        self.preserve_data_on_reward = (
-            os.getenv("TAU_PRESERVE_DATA_ON_REWARD") == "1"
-        )
+        # byte-identical to upstream unless explicitly enabled. Prefer the
+        # constructor argument (wired from RunConfig / the CLI); fall back to
+        # the TAU_STRICT_OUTPUT_MATCH / TAU_PRESERVE_DATA_ON_REWARD env vars
+        # only when the argument is left unset.
+        #   strict_output_match: require whole-token output matches instead of
+        #       a bare substring test (avoids e.g. required output "10" being
+        #       satisfied by "100" anywhere in the agent's reply).
+        #   preserve_data_on_reward: restore self.data after the ground-truth
+        #       action replay in calculate_reward, so the env is left holding
+        #       the agent's final state rather than the GT state.
+        if strict_output_match is None:
+            strict_output_match = os.getenv("TAU_STRICT_OUTPUT_MATCH") == "1"
+        if preserve_data_on_reward is None:
+            preserve_data_on_reward = (
+                os.getenv("TAU_PRESERVE_DATA_ON_REWARD") == "1"
+            )
+        self.strict_output_match = strict_output_match
+        self.preserve_data_on_reward = preserve_data_on_reward
 
     def reset(self, task_index: Optional[int] = None) -> EnvResetResponse:
         if task_index is None:

--- a/tau_bench/envs/retail/env.py
+++ b/tau_bench/envs/retail/env.py
@@ -17,6 +17,8 @@ class MockRetailDomainEnv(Env):
         user_provider: Optional[str] = None,
         task_split: str = "test",
         task_index: Optional[int] = None,
+        strict_output_match: Optional[bool] = None,
+        preserve_data_on_reward: Optional[bool] = None,
     ):
         match task_split:
             case "test":
@@ -37,5 +39,7 @@ class MockRetailDomainEnv(Env):
             user_model=user_model,
             user_provider=user_provider,
             task_index=task_index,
+            strict_output_match=strict_output_match,
+            preserve_data_on_reward=preserve_data_on_reward,
         )
         self.terminate_tools = ["transfer_to_human_agents"]

--- a/tau_bench/run.py
+++ b/tau_bench/run.py
@@ -38,6 +38,8 @@ def run(config: RunConfig) -> List[EnvRunResult]:
         user_model=config.user_model,
         user_provider=config.user_model_provider,
         task_split=config.task_split,
+        strict_output_match=config.strict_output_match,
+        preserve_data_on_reward=config.preserve_data_on_reward,
     )
     agent = agent_factory(
         tools_info=env.tools_info,
@@ -71,6 +73,8 @@ def run(config: RunConfig) -> List[EnvRunResult]:
                 task_split=config.task_split,
                 user_provider=config.user_model_provider,
                 task_index=idx,
+                strict_output_match=config.strict_output_match,
+                preserve_data_on_reward=config.preserve_data_on_reward,
             )
 
             print(f"Running task {idx}")

--- a/tau_bench/types.py
+++ b/tau_bench/types.py
@@ -88,3 +88,6 @@ class RunConfig(BaseModel):
     shuffle: int = 0
     user_strategy: str = "llm"
     few_shot_displays_path: Optional[str] = None
+    # Opt-in reward-precision knobs (default OFF -> upstream scoring unchanged).
+    strict_output_match: bool = False
+    preserve_data_on_reward: bool = False

--- a/tests/test_reward_precision.py
+++ b/tests/test_reward_precision.py
@@ -4,7 +4,50 @@
 The default (non-strict) behaviour must remain byte-identical to upstream's
 substring test; strict mode only tightens matching to token boundaries.
 """
+from unittest.mock import patch
+
+from tau_bench.envs import get_env
 from tau_bench.envs.base import output_matches
+
+
+def _make_env(**flags):
+    def fake_user_completion(*args, **kwargs):
+        message = type("M", (), {"content": "Hi! ###STOP###"})()
+        message.model_dump = lambda: {"role": "assistant", "content": "Hi! ###STOP###"}
+        return type(
+            "R",
+            (),
+            {"choices": [type("C", (), {"message": message})()], "_hidden_params": {"response_cost": 0.0}},
+        )()
+
+    with patch("tau_bench.envs.user.completion", side_effect=fake_user_completion):
+        return get_env(
+            "retail",
+            user_strategy="llm",
+            user_model="gpt-4o",
+            task_split="test",
+            user_provider="openai",
+            task_index=0,
+            **flags,
+        )
+
+
+def test_get_env_defaults_flags_off():
+    env = _make_env()
+    assert env.strict_output_match is False
+    assert env.preserve_data_on_reward is False
+
+
+def test_get_env_threads_flags_true():
+    env = _make_env(strict_output_match=True, preserve_data_on_reward=True)
+    assert env.strict_output_match is True
+    assert env.preserve_data_on_reward is True
+
+
+def test_env_var_fallback_when_flag_unset(monkeypatch):
+    monkeypatch.setenv("TAU_STRICT_OUTPUT_MATCH", "1")
+    env = _make_env()  # flags left unset -> env var fallback applies
+    assert env.strict_output_match is True
 
 
 def test_default_is_substring_match():

--- a/tests/test_reward_precision.py
+++ b/tests/test_reward_precision.py
@@ -1,0 +1,31 @@
+# Copyright Sierra
+"""Tests for the opt-in reward-precision output matcher.
+
+The default (non-strict) behaviour must remain byte-identical to upstream's
+substring test; strict mode only tightens matching to token boundaries.
+"""
+from tau_bench.envs.base import output_matches
+
+
+def test_default_is_substring_match():
+    # Upstream behaviour: bare substring, case-insensitive. Commas are stripped
+    # from the reply content only (not from the required output).
+    assert output_matches("10", "the total is 100")
+    assert output_matches("1000", "you owe 1,000 dollars")
+    assert output_matches("ABC", "order abc shipped")
+
+
+def test_strict_rejects_substring_false_positive():
+    # The motivating bug: required "10" satisfied by "100".
+    assert not output_matches("10", "the total is 100", strict=True)
+    assert not output_matches("12", "order 123 pending", strict=True)
+
+
+def test_strict_still_matches_whole_token():
+    assert output_matches("10", "your order 10 shipped", strict=True)
+    assert output_matches("#w12", "order #w12 ok", strict=True)
+    assert output_matches("1000", "you owe 1,000 dollars", strict=True)
+
+
+def test_strict_is_case_insensitive():
+    assert output_matches("ABC", "order abc shipped", strict=True)


### PR DESCRIPTION
## Summary
Two long-standing reward quirks in `Env.calculate_reward`, each gated behind a **default-OFF** env flag so scoring stays **byte-identical to upstream** unless explicitly enabled.

### 1. `TAU_STRICT_OUTPUT_MATCH=1` — whole-token output matching
Required task outputs are currently checked with a bare substring test:
```python
output.lower() in action.kwargs["content"].lower().replace(",", "")
```
So a required output of `"10"` is satisfied by `"100"` (or any longer number/word) appearing anywhere in the agent's reply — spurious reward credit. The flag anchors the match to token boundaries via a new, testable `output_matches()` helper.

### 2. `TAU_PRESERVE_DATA_ON_REWARD=1` — restore agent state after reward replay
`calculate_reward` reloads the DB and replays ground-truth actions, leaving `self.data` holding the **GT end-state** rather than the agent's final state. The flag snapshots and restores the agent's data after the GT replay, so callers can inspect post-reward state without surprise.

## Safety
Both flags default OFF. With neither set, behavior and scoring are unchanged from upstream.

## Testing
`tests/test_reward_precision.py` — 4 tests (default substring behavior preserved; strict mode rejects the `"10"`/`"100"` false positive while still matching whole tokens; case-insensitivity). All pass.

## Related issues
- Addresses #12 (Concerns about scoring expected outputs) — implements the **opt-in grading strategy** suggested in that thread, as a default-OFF whole-token matcher rather than a bare substring check.
- Relates to #57 (High Variance in final accuracy) — spurious substring credit (e.g. required `"10"` satisfied by `"100"`) can inflate run-to-run reward variance; strict mode removes that class of false positives.

## How to verify (≈4s, no network)
```bash
pip install -e . && PYTHONPATH=. pytest tests/test_reward_precision.py -q
```
Result on this branch: **7 passed** — 4 matcher-behavior tests (default substring preserved; strict mode rejects the `"10"`/`"100"` false positive) + 3 plumbing tests (flags default OFF; threaded through `get_env`; env-var fallback).